### PR TITLE
Enable constants system for file names

### DIFF
--- a/TeslaGamesEngine/TeslaGamesEngine.cpp
+++ b/TeslaGamesEngine/TeslaGamesEngine.cpp
@@ -158,12 +158,12 @@ int main()
 
 	//Audio system setup
 	AudioEngine audioSystem = AudioEngine();
-	AudioBoomBox audioObject = audioSystem.createBoomBox(2);
-	AudioBoomBox audioObject2 = audioSystem.createBoomBox(3);
+	AudioBoomBox audioObject = audioSystem.createBoomBox(audioConstants::SOUND_FILE_TTG_MAIN_MENU);
+	AudioBoomBox audioObject2 = audioSystem.createBoomBox(audioConstants::SOUND_FILE_TTG_RACE);
 
 	//The key is now that multiple sounds can be played at once. As long as sound card can support it
 	//Comment out one sound if you dont wanna hear it
-	audioObject.playSound();
+	//audioObject.playSound();
 	audioObject2.playSound();
 
 	//End of audio system setup/demo

--- a/TeslaGamesEngine/audioEngine.h
+++ b/TeslaGamesEngine/audioEngine.h
@@ -1,8 +1,7 @@
 #pragma once
 //We are using fopen, silence the error
 #define _CRT_SECURE_NO_WARNINGS
-#include <openAL/al.h>
-#include <openAL/alc.h>
+#include "AudioBoomBox.h"
 #include <string>
 #include <cstdio>
 #include <cstdlib>
@@ -10,7 +9,14 @@
 #include <cstring>
 #include <vector>
 #include <memory>
-#include "AudioBoomBox.h"
+
+namespace audioConstants
+{
+	const int SOUND_FILE_BOUNCE = 0;
+	const int SOUND_FILE_FINALCOUNT = 1;
+	const int SOUND_FILE_TTG_MAIN_MENU = 2;
+	const int SOUND_FILE_TTG_RACE = 3;
+}
 
 class AudioEngine
 {


### PR DESCRIPTION
You can still play multiple audio tracks, just uncomment. I have it like this by default so it sounds more badass when you launch